### PR TITLE
Fix telegram username form

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backend",
-  "version": "0.0.1",
+  "version": "1.22.19",
   "description": "",
   "author": "",
   "private": true,

--- a/frontend/src/pages/dashboard/profile/index.tsx
+++ b/frontend/src/pages/dashboard/profile/index.tsx
@@ -28,7 +28,7 @@ export default function Profile() {
         path="edit"
         element={
           <Box sx={{ pt: 5, minHeight: '100vh', pb: 20, maxWidth: 600, margin: '0 auto' }}>
-            <ProfileEditForm isExistingUser={true} />
+            <ProfileEditForm buttonText="Save Changes" isExistingUser />
           </Box>
         }
       />

--- a/frontend/src/pages/onboarding/NewUserProfile.tsx
+++ b/frontend/src/pages/onboarding/NewUserProfile.tsx
@@ -31,7 +31,7 @@ export default function Profile() {
         <Typography variant="subtitle1" gutterBottom sx={{ mt: 5, mb: 1 }}>
           Fill in your details to be shown to other climbers
         </Typography>
-        <ProfileEditForm isExistingUser={false} />
+        <ProfileEditForm isExistingUser buttonText="Next" />
       </Container>
     </Page>
   );

--- a/frontend/src/sections/auth/login/LoginForm.tsx
+++ b/frontend/src/sections/auth/login/LoginForm.tsx
@@ -1,29 +1,49 @@
 // @mui
-import { Stack, Button, Typography } from '@mui/material';
+import { Stack, Button, Typography, Box } from '@mui/material';
 // components
 import Iconify from '../../../components/Iconify';
 //
 import { BE_API } from 'src/utils/api';
 // @ts-ignore (react-telegram-login is missing a @types file)
 import TelegramLoginButton from 'react-telegram-login';
+import { useEffect } from 'react';
 
 // ----------------------------------------------------------------------
 
 export default function LoginForm() {
+  useEffect(() => {
+    document.querySelector('ifrmae');
+  }, []);
+
   return (
     <>
-      <Stack direction="column" alignItems="center" justifyContent="space-between" spacing={1.5}>
-        <Button
-          fullWidth
-          size="large"
-          color="error"
-          variant="outlined"
-          startIcon={<Iconify icon={'ant-design:google-outlined'} width={24} height={24} sx={{ mx: 1 }} />}
-          href={`${process.env.REACT_APP_HOST_API_KEY}${BE_API.auth.google}`}
-        >
-          <Typography variant="button">Continue with Google</Typography>
-        </Button>
-        <TelegramLoginButton dataAuthUrl={`${process.env.REACT_APP_HOST_API_KEY}${BE_API.auth.telegramRedirect}`} botName={`${process.env.REACT_APP_TELEGRAM_OAUTH_BOT_USERNAME}`} />
+      <Stack sx={{ maxWidth: 600 }} direction="column" alignItems="center" justifyContent="space-between" spacing={1.5}>
+        <Box sx={{ width: '100%', mb: 2 }}>
+          <Typography variant="subtitle2" sx={{ color: 'text.secondary', mb: 2 }}>
+            Recommended for smoother onboarding
+          </Typography>
+          <TelegramLoginButton
+            dataAuthUrl={`${process.env.REACT_APP_HOST_API_KEY}${BE_API.auth.telegramRedirect}`}
+            botName={`${process.env.REACT_APP_TELEGRAM_OAUTH_BOT_USERNAME}`}
+          />
+        </Box>
+        <Box sx={{ width: '100%' }}>
+          <Typography variant="subtitle2" sx={{ color: 'text.secondary', mb: 2 }}>
+            Other Option
+          </Typography>
+          <Button
+            fullWidth
+            size="large"
+            color="error"
+            variant="outlined"
+            startIcon={
+              <Iconify icon={'ant-design:google-outlined'} width={24} height={24} sx={{ mx: 1 }} />
+            }
+            href={`${process.env.REACT_APP_HOST_API_KEY}${BE_API.auth.google}`}
+          >
+            <Typography variant="button">Continue with Google</Typography>
+          </Button>
+        </Box>
       </Stack>
     </>
   );

--- a/frontend/src/sections/auth/login/LoginForm.tsx
+++ b/frontend/src/sections/auth/login/LoginForm.tsx
@@ -6,15 +6,10 @@ import Iconify from '../../../components/Iconify';
 import { BE_API } from 'src/utils/api';
 // @ts-ignore (react-telegram-login is missing a @types file)
 import TelegramLoginButton from 'react-telegram-login';
-import { useEffect } from 'react';
 
 // ----------------------------------------------------------------------
 
 export default function LoginForm() {
-  useEffect(() => {
-    document.querySelector('ifrmae');
-  }, []);
-
   return (
     <>
       <Stack sx={{ maxWidth: 600 }} direction="column" alignItems="center" justifyContent="space-between" spacing={1.5}>

--- a/frontend/src/sections/onboarding/UsernameForm.tsx
+++ b/frontend/src/sections/onboarding/UsernameForm.tsx
@@ -1,6 +1,6 @@
 import * as Yup from 'yup';
 import { yupResolver } from '@hookform/resolvers/yup';
-import { useEffect, useMemo, useContext } from 'react';
+import { useContext, useEffect } from 'react';
 // form
 import { useForm } from 'react-hook-form';
 // @mui
@@ -10,7 +10,6 @@ import { Card, Grid, Stack, FormHelperText } from '@mui/material';
 import { FormProvider, RHFTextField } from '../../components/hook-form';
 import { useSnackbar } from 'notistack';
 import {
-  SUPPORT_EMAIL,
   MIN_USERNAME_LEN,
   MAX_USERNAME_LEN,
   REGEX_USERNAME,
@@ -47,11 +46,10 @@ export default function UsernameForm({ onExit }: Props) {
 
   const methods = useForm<FormValuesProps>({
     resolver: yupResolver(NewProfileSchema),
-    defaultValues: { username: '' },
+    defaultValues: { username: auth.user?.telegramHandle },
   });
 
   const {
-    reset,
     setValue,
     handleSubmit,
     formState: { isSubmitting, errors },
@@ -71,6 +69,11 @@ export default function UsernameForm({ onExit }: Props) {
       throw error;
     }
   };
+
+  // Temp fix to pass form if climber doesn't change their auto-filled username
+  useEffect(() => {
+    newUserContext.updateUsername(auth.user?.telegramHandle || '');
+  }, [auth.user?.telegramHandle, newUserContext]);
 
   return (
     <FormProvider methods={methods} onSubmit={handleSubmit(onSubmit)}>

--- a/frontend/src/sections/onboarding/UsernameForm.tsx
+++ b/frontend/src/sections/onboarding/UsernameForm.tsx
@@ -46,6 +46,8 @@ export default function UsernameForm({ onExit }: Props) {
 
   const methods = useForm<FormValuesProps>({
     resolver: yupResolver(NewProfileSchema),
+    // To be fixed: Auto-populate username with telegram handle for now
+    // In the future can just skip this form
     defaultValues: { username: auth.user?.telegramHandle },
   });
 

--- a/frontend/src/sections/profile/ProfileEditForm.tsx
+++ b/frontend/src/sections/profile/ProfileEditForm.tsx
@@ -33,9 +33,10 @@ interface FormValuesProps extends User {}
 
 type Props = {
   isExistingUser: boolean;
+  buttonText: string;
 };
 
-export default function ProfileEditForm({ isExistingUser }: Props) {
+export default function ProfileEditForm({ isExistingUser, buttonText }: Props) {
   const auth = useAuth();
   const { enqueueSnackbar } = useSnackbar();
   const newUserContext = useContext(NewUserContext);
@@ -137,7 +138,7 @@ export default function ProfileEditForm({ isExistingUser }: Props) {
                 variant="contained"
                 loading={isSubmitting}
               >
-                {isExistingUser ? `Save Changes` : `Next`}
+                {buttonText}
               </LoadingButton>
             </Stack>
           </Card>


### PR DESCRIPTION
## Describe your changes

- Temp fix for iframe styling
  - No simple way to style Telegram iframe
  - Saw an option here https://stackoverflow.com/questions/56347902/telegram-authorization-without-default-button
    - But not sure how to integrate with our UI
- Temp fix for onboarding
  - Auto populate ProfileEditForm by setting isEdit to true
  - Auto populate Username with Telegram username
  - This code can be deleted when @CrownKira is done with onboarding flow

## Issue ticket number and link

#60 

## Screenshots (if appropriate):

<img width="1031" alt="image" src="https://user-images.githubusercontent.com/24352004/195812374-14a87d9f-57be-4e61-ab7f-68e71802bc79.png">
<img width="332" alt="image" src="https://user-images.githubusercontent.com/24352004/195812423-229340d7-c249-4a21-a0e6-170614d7a932.png">


## Checklist before requesting a review

- [x] I have performed a self-review of my code
