### PR TITLE
fix: add start date time for jio search

### DIFF
--- a/frontend/src/pages/dashboard/jios/list/allJios/JioCardList.tsx
+++ b/frontend/src/pages/dashboard/jios/list/allJios/JioCardList.tsx
@@ -11,6 +11,7 @@ import { listJios, ListJiosArgs } from 'src/store/reducers/jios';
 import { getDateTimeString } from 'src/utils/formatTime';
 import { Link } from 'react-router-dom';
 import { PATH_DASHBOARD } from '../../../../../routes/paths';
+import { addMinutes } from 'date-fns';
 
 export default function JioCardList() {
   const dispatch = useDispatch();
@@ -88,7 +89,12 @@ export default function JioCardList() {
 
   useEffect(() => {
     if (!jioSearchValues) {
-      dispatch(listJios({}));
+      dispatch(
+        listJios({
+          // Starting climbs 30 min after current ime
+          startDateTime: addMinutes(new Date(), 30).toISOString(),
+        })
+      );
       return;
     }
 


### PR DESCRIPTION
## Describe your changes

- Search jios
  - Start date time set to 30 mins after now

Before
- All jios are displayed

## Issue ticket number and link

## Screenshots (if appropriate):

## Checklist before requesting a review

- [x] I have performed a self-review of my code
