### PR TITLE
feat: add to home screen instruction button on profile page & fix: add to home screen prompts should only show on mobile

### DIFF
--- a/frontend/src/components/a2hs/AddToHomeScreen.tsx
+++ b/frontend/src/components/a2hs/AddToHomeScreen.tsx
@@ -4,16 +4,7 @@ import { Button, Stack, Typography } from '@mui/material';
 import { InlineIcon } from '@iconify/react';
 import { isiOS, isPWA } from 'src/utils/device';
 import useLocalStorage from '../../hooks/useLocalStorage';
-
-// Note that BeforeInstallPromptEvent is still a non-standard experimental feature, and may not work for every user.
-interface IBeforeInstallPromptEvent extends Event {
-  readonly platforms: string[];
-  readonly userChoice: Promise<{
-    outcome: 'accepted' | 'dismissed';
-    platform: string;
-  }>;
-  prompt(): Promise<void>;
-}
+import IBeforeInstallPromptEvent from './IBeforeInstallPromptEvent';
 
 export default function AddToHomeScreen() {
   const { enqueueSnackbar, closeSnackbar } = useSnackbar();

--- a/frontend/src/components/a2hs/AddToHomeScreenButton.tsx
+++ b/frontend/src/components/a2hs/AddToHomeScreenButton.tsx
@@ -1,0 +1,60 @@
+import { useState } from 'react';
+import { DialogAnimate } from "src/components/animate";
+import { Button, Stack, Typography } from '@mui/material';
+import Iconify from 'src/components/Iconify';
+import { InlineIcon } from '@iconify/react';
+import { isiOS, isPWA, isMobile } from 'src/utils/device';
+
+export default function AddToHomeScreenButton() {
+  const [isOpenModal, setIsOpenModal] = useState<boolean>(false);
+  const handleOpenModal = () => setIsOpenModal(true);
+  const handleCloseModal = () => setIsOpenModal(false);
+  // Application has already been installed, or user is accessing from a non-mobile device
+  // Install button should not be displayed
+  if (isPWA() || !isMobile()) {
+    return <></>;
+  }
+
+  return (
+    <>
+      <Button
+        startIcon={<Iconify icon="bxs:download" />}
+        variant={'outlined'}
+        onClick={handleOpenModal}
+        fullWidth
+      >
+        Add ClimbJios to your homescreen!
+      </Button>
+      <DialogAnimate open={isOpenModal} onClose={handleCloseModal}>
+        {
+        isiOS()
+          ? <Stack spacing={3} sx={{ p: 3 }}>
+              <Typography>
+                Add the ClimbJios app to your device's homescreen for easy access anytime.
+              </Typography>
+              <Stack spacing={1}>
+                <Typography>
+                  1. Tap on <InlineIcon icon="uil:upload-alt" />
+                </Typography>
+                <Typography>2. Select Add to Home Screen <InlineIcon icon="fluent:add-square-24-regular" /></Typography>
+              </Stack>
+            </Stack>
+          : <Stack spacing={3} sx={{ p: 3 }}>
+              <Typography>
+                Add the ClimbJios app to your device's homescreen for easy access anytime.
+              </Typography>
+              <Stack spacing={1}>
+                <Typography>
+                  1. Tap on <InlineIcon icon="carbon:overflow-menu-vertical" />
+                </Typography>
+                <Typography>2. Select <InlineIcon icon="material-symbols:add-to-home-screen" /> Install or <InlineIcon icon="material-symbols:add-to-home-screen" /> Install App</Typography>
+              </Stack>
+              <Typography>
+                For older devices, tap on <InlineIcon icon="ci:home-alt-plus" /> next to the URL bar.
+              </Typography>
+            </Stack>
+        }
+      </DialogAnimate>
+    </>
+  );
+}

--- a/frontend/src/components/a2hs/IBeforeInstallPromptEvent.ts
+++ b/frontend/src/components/a2hs/IBeforeInstallPromptEvent.ts
@@ -1,0 +1,9 @@
+// Note that BeforeInstallPromptEvent is still a non-standard experimental feature, and may not work for every user.
+export default interface IBeforeInstallPromptEvent extends Event {
+  readonly platforms: string[];
+  readonly userChoice: Promise<{
+    outcome: 'accepted' | 'dismissed';
+    platform: string;
+  }>;
+  prompt(): Promise<void>;
+}

--- a/frontend/src/pages/dashboard/jios/list/index.tsx
+++ b/frontend/src/pages/dashboard/jios/list/index.tsx
@@ -16,6 +16,7 @@ import { IconStyle } from 'src/utils/common';
 import { PATH_DASHBOARD } from 'src/routes/paths';
 import { useSearchParams } from 'react-router-dom';
 import AddToHomeScreen from 'src/components/a2hs/AddToHomeScreen';
+import { isMobile } from 'src/utils/device';
 
 const StyledTab = styled(Tab)({
   '&.MuiButtonBase-root': {
@@ -157,7 +158,7 @@ export default function JiosList() {
 
   return (
     <Box sx={{ pt: 5, pb: 20, minHeight: '100vh', maxWidth: 600, margin: '0 auto' }}>
-      <AddToHomeScreen />
+      {isMobile() && <AddToHomeScreen />}
       <TabContext value={tabValue}>
         <Box>
           {renderSearchButton()}

--- a/frontend/src/pages/dashboard/profile/MyProfile/index.tsx
+++ b/frontend/src/pages/dashboard/profile/MyProfile/index.tsx
@@ -8,6 +8,7 @@ import Iconify from '../../../../components/Iconify';
 import ProfileBetas from '../../../../components/profile/ProfileBetas';
 import useLogout from '../../../../hooks/auth/useLogout';
 import { PATH_DASHBOARD } from '../../../../routes/paths';
+import AddToHomeScreenButton from 'src/components/a2hs/AddToHomeScreenButton';
 
 export default function MyProfile() {
   const { identity: user } = useGetIdentity();
@@ -36,6 +37,7 @@ export default function MyProfile() {
               </Button>
             }
           />
+          <AddToHomeScreenButton />
           <Button
             startIcon={<Iconify icon="material-symbols:logout-rounded" />}
             variant={'outlined'}

--- a/frontend/src/utils/device.ts
+++ b/frontend/src/utils/device.ts
@@ -14,3 +14,24 @@ export function isiOS() {
 export function isPWA() {
   return window.matchMedia('(display-mode: standalone)').matches;
 }
+
+export function isMobile() {
+  let hasTouchScreen = false;
+  if ("maxTouchPoints" in navigator) {
+    hasTouchScreen = navigator.maxTouchPoints > 0;
+  } else {
+    const mQ = matchMedia?.("(pointer:coarse)");
+    if (mQ?.media === "(pointer:coarse)") {
+      hasTouchScreen = !!mQ.matches;
+    } else if ("orientation" in window) {
+      hasTouchScreen = true; // deprecated, but good fallback
+    } else {
+      // Only as a last resort, fall back to user agent sniffing
+      const UA = navigator.userAgent;
+      hasTouchScreen =
+        /\b(BlackBerry|webOS|iPhone|IEMobile)\b/i.test(UA) ||
+        /\b(Android|Windows Phone|iPad|iPod)\b/i.test(UA);
+    }
+  }
+  return hasTouchScreen;
+}


### PR DESCRIPTION
## Describe your changes
- Added button to display instructions for user to add to home screen on their profile page
- Fix to make add to home screen prompts only appear on mobile devices

## Issue ticket number and link

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/69179233/197849105-062d9942-3675-4c4f-8575-7a5c53c55ec5.png)
![image](https://user-images.githubusercontent.com/69179233/197849120-5801d6b7-af61-4259-84b4-05acfd83fad3.png)
![image](https://user-images.githubusercontent.com/69179233/197849140-d6e89440-6e7c-4f6c-885a-ccafe23b8880.png)

## Checklist before requesting a review

- [x] I have performed a self-review of my code
