### PR TITLE
feat: add support for refresh token flow across multiple devices

### DIFF
--- a/backend/src/app/app.module.ts
+++ b/backend/src/app/app.module.ts
@@ -33,6 +33,7 @@ import { GymGradesDaoModule } from '../database/daos/gymGrades/gymGrades.dao.mod
 import { WallsDaoModule } from '../database/daos/walls/walls.dao.module';
 import { WallsModule } from '../walls/walls.module';
 import { LoggerModule } from '../utils/logger/logger.module';
+import { RefreshTokensDaoModule } from '../database/daos/refreshTokens/refreshTokens.dao.module';
 
 @Module({
   imports: [
@@ -56,6 +57,7 @@ import { LoggerModule } from '../utils/logger/logger.module';
     ColorsDaoModule,
     WallsDaoModule,
     BetasDaoModule,
+    RefreshTokensDaoModule,
 
     // Modules with controllers
     AuthModule,

--- a/backend/src/auth/jwtAuth/jwtAuth.service.ts
+++ b/backend/src/auth/jwtAuth/jwtAuth.service.ts
@@ -1,15 +1,15 @@
 import { HttpException, Injectable } from '@nestjs/common';
 import { JwtService } from '@nestjs/jwt';
-import { UserDaoService } from '../../database/daos/users/user.dao.service';
 import { ConstantsService } from '../../utils/constants/constants.service';
 import { JwtPayload } from '../../utils/types';
+import { RefreshTokensDaoService } from '../../database/daos/refreshTokens/refreshTokens.dao.service';
 
 @Injectable()
 export class JwtAuthService {
   constructor(
     private readonly jwtService: JwtService,
     private readonly constantsService: ConstantsService,
-    private readonly userDaoService: UserDaoService,
+    private readonly refreshTokensDaoService: RefreshTokensDaoService,
   ) {}
 
   private generateAccessToken(payload: JwtPayload) {
@@ -36,12 +36,23 @@ export class JwtAuthService {
     }
   }
 
-  async generateJwts(user) {
+  /**
+   * When `oldToken` is defined, modify the corresponding existing refresh token entry inplace. (i.e. during refresh token flow)
+   * If undefined, create a new database entry (i.e. when signing in)
+   */
+  async generateJwts(user, oldToken?: string) {
     const payload: JwtPayload = { id: user.id };
     const accessToken: string = this.generateAccessToken(payload);
     const refreshToken: string = this.generateRefreshToken(payload);
 
-    await this.userDaoService.updateById(user.id, { refreshToken });
+    if (oldToken) {
+      await this.refreshTokensDaoService.patchByRefreshToken(
+        oldToken,
+        refreshToken,
+      );
+    } else {
+      await this.refreshTokensDaoService.create(user.id, refreshToken);
+    }
 
     return {
       accessToken,
@@ -51,11 +62,17 @@ export class JwtAuthService {
 
   async generateJwtsFromRefreshToken(refreshToken: string) {
     const user = this.verifyRefreshToken(refreshToken);
-    const dbUser = await this.userDaoService.findById(user.id);
-    if (dbUser.refreshToken !== refreshToken) {
+    const userRefreshTokens = await this.refreshTokensDaoService.findByUserId(
+      user.id,
+    );
+    const isValidRefreshToken = userRefreshTokens.some(
+      (r) => r.refreshToken === refreshToken,
+    );
+
+    if (!isValidRefreshToken) {
       throw new HttpException('Invalid refresh token', 401);
     }
 
-    return this.generateJwts(user);
+    return this.generateJwts(user, refreshToken);
   }
 }

--- a/backend/src/cronjob/cronjob.module.ts
+++ b/backend/src/cronjob/cronjob.module.ts
@@ -8,6 +8,7 @@ import { CronjobService } from './cronjob.service';
 import { LoggerModule } from '../utils/logger/logger.module';
 import { PostModule } from '../posts/posts.module';
 import { GymsDaoModule } from '../database/daos/gyms/gyms.dao.module';
+import { RefreshTokensDaoModule } from '../database/daos/refreshTokens/refreshTokens.dao.module';
 
 @Module({
   imports: [
@@ -19,6 +20,7 @@ import { GymsDaoModule } from '../database/daos/gyms/gyms.dao.module';
     UserDaoModule,
     PostDaoModule,
     GymsDaoModule,
+    RefreshTokensDaoModule,
 
     PostModule,
   ],

--- a/backend/src/cronjob/cronjob.service.ts
+++ b/backend/src/cronjob/cronjob.service.ts
@@ -4,6 +4,7 @@ import { LoggerService } from '../utils/logger/logger.service';
 import { PostsDaoService } from '../database/daos/posts/posts.dao.service';
 import { UserDaoService } from '../database/daos/users/user.dao.service';
 import { PostService } from '../posts/post.service';
+import { RefreshTokensDaoService } from '../database/daos/refreshTokens/refreshTokens.dao.service';
 
 @Injectable()
 export class CronjobService {
@@ -12,6 +13,7 @@ export class CronjobService {
     private readonly userDaoService: UserDaoService,
     private readonly postService: PostService,
     private readonly postsDaoService: PostsDaoService,
+    private readonly refreshTokensDaoService: RefreshTokensDaoService,
   ) {}
 
   @Cron(CronExpression.EVERY_3_HOURS)
@@ -27,5 +29,10 @@ export class CronjobService {
   @Cron(CronExpression.EVERY_30_MINUTES)
   closeOutdatedPosts() {
     return this.postService.updateExpiredOpenPosts();
+  }
+
+  @Cron(CronExpression.EVERY_DAY_AT_MIDNIGHT)
+  cleanUpExpiredRefreshTokens() {
+    return this.refreshTokensDaoService.deleteExpired();
   }
 }

--- a/backend/src/database/daos/refreshTokens/refreshTokens.dao.module.ts
+++ b/backend/src/database/daos/refreshTokens/refreshTokens.dao.module.ts
@@ -1,0 +1,9 @@
+import { Global, Module } from '@nestjs/common';
+import { RefreshTokensDaoService } from './refreshTokens.dao.service';
+
+@Global()
+@Module({
+  providers: [RefreshTokensDaoService],
+  exports: [RefreshTokensDaoService],
+})
+export class RefreshTokensDaoModule {}

--- a/backend/src/database/daos/refreshTokens/refreshTokens.dao.service.ts
+++ b/backend/src/database/daos/refreshTokens/refreshTokens.dao.service.ts
@@ -1,0 +1,26 @@
+import { Inject, Injectable } from '@nestjs/common';
+import { ModelClass } from 'objection';
+import { RefreshTokenModel } from '../../models/refreshToken.model';
+
+@Injectable()
+export class RefreshTokensDaoService {
+  constructor(
+    @Inject('RefreshTokenModel')
+    private refreshTokenModel: ModelClass<RefreshTokenModel>,
+  ) {}
+
+  create(userId: string, refreshToken: string) {
+    return this.refreshTokenModel.query().insert({ userId, refreshToken });
+  }
+
+  patchByRefreshToken(oldRefreshToken: string, newRefreshToken: string) {
+    return this.refreshTokenModel
+      .query()
+      .patch({ refreshToken: newRefreshToken })
+      .where({ refreshToken: oldRefreshToken });
+  }
+
+  findByUserId(userId: string) {
+    return this.refreshTokenModel.query().select().where({ userId });
+  }
+}

--- a/backend/src/database/daos/refreshTokens/refreshTokens.dao.service.ts
+++ b/backend/src/database/daos/refreshTokens/refreshTokens.dao.service.ts
@@ -23,4 +23,22 @@ export class RefreshTokensDaoService {
   findByUserId(userId: string) {
     return this.refreshTokenModel.query().select().where({ userId });
   }
+
+  /**
+   * To be run by cronjob. Deletes entries that have not been updated for at least a month.
+   */
+  deleteExpired() {
+    return this.refreshTokenModel
+      .query()
+      .delete()
+      .where(
+        'updatedAt',
+        '<',
+        (() => {
+          let date = new Date();
+          date.setDate(new Date().getDate() - 31);
+          return date;
+        })(),
+      );
+  }
 }

--- a/backend/src/database/database.module.ts
+++ b/backend/src/database/database.module.ts
@@ -16,6 +16,7 @@ import { UserModel } from './models/user.model';
 import { UserProfileModel } from './models/userProfile.model';
 import { UserProfileFavouriteGymModel } from './models/userProfileFavouriteGym.model';
 import { BetaModel } from './models/beta.model';
+import { RefreshTokenModel } from './models/refreshToken.model';
 
 const models = [
   GymModel,
@@ -32,6 +33,7 @@ const models = [
   ColorModel,
   WallModel,
   BetaModel,
+  RefreshTokenModel,
 ];
 const modelProviders = models.map((model) => ({
   provide: model.name,

--- a/backend/src/database/migrations/20221031143616_add-refresh-token-table.ts
+++ b/backend/src/database/migrations/20221031143616_add-refresh-token-table.ts
@@ -1,0 +1,51 @@
+import { Knex } from 'knex';
+
+export async function up(knex: Knex): Promise<void> {
+  return knex.schema
+    .createTable('refreshTokens', (t) => {
+      t.increments('id').primary();
+      t.uuid('userId').references('id').inTable('users').notNullable();
+      t.string('refreshToken').notNullable();
+      t.timestamps(true, true);
+    })
+    .then(() => knex.select().from('users'))
+    .then((users) =>
+      Promise.all(
+        users.map((u) =>
+          knex
+            .insert({ userId: u.id, refreshToken: u.refreshToken })
+            .into('refreshTokens'),
+        ),
+      ),
+    )
+    .then(() =>
+      knex.schema.table('users', (t) => {
+        t.dropColumn('refreshToken');
+      }),
+    );
+}
+
+export async function down(knex: Knex): Promise<void> {
+  return knex.schema
+    .table('users', (t) => {
+      t.string('refreshToken');
+    })
+    .then(() => knex.select().from('users'))
+    .then((users) =>
+      Promise.all(
+        users.map((u) =>
+          knex
+            .select()
+            .from('refreshTokens')
+            .where('userId', u.id)
+            .first()
+            .then((e) =>
+              knex('users')
+                .update({ refreshToken: e.refreshToken })
+                .where('id', u.id),
+            ),
+        ),
+      ),
+    )
+    .then(() => knex.schema.dropTable('refreshTokens'));
+}

--- a/backend/src/database/models/refreshToken.model.ts
+++ b/backend/src/database/models/refreshToken.model.ts
@@ -1,0 +1,8 @@
+import { BaseModel } from './base.model';
+
+export class RefreshTokenModel extends BaseModel {
+  static tableName = 'refreshTokens';
+
+  readonly userId: string;
+  readonly refreshToken: string;
+}

--- a/backend/src/database/models/user.model.ts
+++ b/backend/src/database/models/user.model.ts
@@ -9,7 +9,6 @@ export class UserModel extends BaseModel {
   readonly authProvider: AuthProvider;
   readonly authProviderId: string;
   readonly oauthName: string;
-  readonly refreshToken?: string;
   readonly email?: string;
 
   readonly userProfile: UserProfileModel;

--- a/backend/src/database/seeds/02-Users.ts
+++ b/backend/src/database/seeds/02-Users.ts
@@ -19,14 +19,12 @@ export async function seed(knex: Knex): Promise<void> {
       oauthName: 'Alison Lim',
       authProvider: 'google',
       authProviderId: 'authTestId1',
-      refreshToken: 'refresh_token',
     },
     {
       id: MOCK_USER_2_UUID,
       oauthName: 'Bob Tan',
       authProvider: 'telegram',
       authProviderId: 'authTestId2',
-      refreshToken: 'refresh_token',
     },
   ]);
 }

--- a/backend/test/app.e2e-spec.ts
+++ b/backend/test/app.e2e-spec.ts
@@ -145,16 +145,23 @@ describe('Backend (e2e)', () => {
         expect.objectContaining({
           id: expect.anything(),
           authProvider: 'telegram',
-          refreshToken: expect.anything(),
           authProviderId: 'telegram_id',
           email: null,
           oauthName: 'first_name last_name',
         }),
       );
 
+      const refreshToken = (
+        await knex(knexTestDatabaseConfig)
+          .select()
+          .from('refreshTokens')
+          .where('userId', insertedUser.id)
+          .first()
+      ).refreshToken;
+
       const { body } = await request(app.getHttpServer())
         .post(`${prefix}/refresh`)
-        .send({ refreshToken: insertedUser.refreshToken })
+        .send({ refreshToken })
         .expect(201);
 
       expect(body).toEqual(
@@ -314,8 +321,8 @@ describe('Backend (e2e)', () => {
           numPasses: 3,
           price: 18,
           gymId: 3,
-          startDateTime: getDateFromNow(1, 0).toISOString(),
-          endDateTime: getDateFromNow(1, 1).toISOString(),
+          startDateTime: getDateFromNow(1, 0, 0).toISOString(),
+          endDateTime: getDateFromNow(1, 0, 1).toISOString(),
           openToClimbTogether: true,
           optionalNote: 'Hi there! Nice to meet u',
         };
@@ -546,8 +553,8 @@ describe('Backend (e2e)', () => {
           numPasses: 3,
           price: 18,
           gymId: 3,
-          startDateTime: getDateFromNow(1, 0).toISOString(),
-          endDateTime: getDateFromNow(1, 1).toISOString(),
+          startDateTime: getDateFromNow(1, 0, 0).toISOString(),
+          endDateTime: getDateFromNow(1, 0, 1).toISOString(),
           openToClimbTogether: true,
           optionalNote: 'Hi there! Nice to meet u',
         };

--- a/backend/test/helpers.ts
+++ b/backend/test/helpers.ts
@@ -1,9 +1,14 @@
 export const getDateFromNow = (
   daysIntoTheFuture: number,
   hoursIntoTheFuture: number,
+  minutesIntoTheFuture: number,
 ) => {
   let date = new Date();
   date.setDate(new Date().getDate() + daysIntoTheFuture);
-  date.setTime(date.getTime() + hoursIntoTheFuture * 60 * 60 * 1000);
+  date.setTime(
+    date.getTime() +
+      hoursIntoTheFuture * 60 * 60 * 1000 +
+      minutesIntoTheFuture * 1000 * 60,
+  );
   return date;
 };


### PR DESCRIPTION
## Describe your changes
As per title. Each device should have its own set of jwt tokens. This means that the refresh token can uniquely identify the device if it is updated inplace during the refresh token flow.

We should probably add a cronjob to remove entries from this table after 30 days have passed since the 'updated_at' column in the db

- [x] I have performed a self-review of my code
