### PR TITLE
fix: search results for type 'other'

### DIFF
--- a/backend/src/database/daos/posts/posts.dao.service.ts
+++ b/backend/src/database/daos/posts/posts.dao.service.ts
@@ -86,7 +86,8 @@ export class PostsDaoService {
         } else if (value === PostType.SELLER) {
           query.where('type', PostType.BUYER);
         } else {
-          query.where('type', PostType.OTHER);
+          // PostType.OTHERS: return posts that have 'open to climb with others'
+          query.where('openToClimbTogether', true);
         }
       } else {
         query.where(key, value);

--- a/frontend/src/pages/dashboard/jios/list/allJios/JioCardList.tsx
+++ b/frontend/src/pages/dashboard/jios/list/allJios/JioCardList.tsx
@@ -94,10 +94,7 @@ export default function JioCardList() {
       endDateTime: getDateTimeString(date, endTiming),
     };
 
-    // Add jio type to search params iff there's a preference to buy or sell passes
-    if (type !== 'other') {
-      searchParams.type = type;
-    }
+    searchParams.type = type;
 
     dispatch(listJios(searchParams));
   }, [version, dispatch, jioSearchValues]);


### PR DESCRIPTION
## Describe your changes
Searching for 'looking for friends to climb with' should return all posts with 'open to climb with others'.

Also, by default all posts with PostType.OTHER have 'openToClimbWithOthers' set to true

## Checklist before requesting a review

- [x] I have performed a self-review of my code
