### PR TITLE
fix: null date logic

### DIFF
--- a/frontend/src/@types/jio.ts
+++ b/frontend/src/@types/jio.ts
@@ -11,8 +11,8 @@ export interface Jio {
   updatedAt: string;
   openToClimbTogether: boolean;
   isClosed: boolean;
-  startDateTime: string | null;
-  endDateTime: string | null;
+  startDateTime: string;
+  endDateTime: string;
   type: JioType;
   gym: Gym;
   numPasses: number;

--- a/frontend/src/components/hook-form/RHFDatePicker.tsx
+++ b/frontend/src/components/hook-form/RHFDatePicker.tsx
@@ -2,7 +2,7 @@
 import { useFormContext, Controller } from 'react-hook-form';
 // @mui
 import { IconButton, Stack, TextField } from '@mui/material';
-import { DatePicker } from '@mui/x-date-pickers';
+import { MobileDatePicker } from '@mui/x-date-pickers';
 import { AdapterDayjs } from '@mui/x-date-pickers/AdapterDayjs';
 import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
 import Iconify from 'src/components/Iconify';
@@ -26,7 +26,7 @@ export default function RHFDatePicker({ name, label }: Props) {
       render={({ field: { ref, ...field }, fieldState: { error } }) => (
         <Stack sx={{ position: 'relative' }}>
           <LocalizationProvider dateAdapter={AdapterDayjs}>
-            <DatePicker
+            <MobileDatePicker
               inputRef={ref}
               disableOpenPicker
               minDate={new Date()}

--- a/frontend/src/pages/dashboard/jios/forms/JiosCreateEditForm.tsx
+++ b/frontend/src/pages/dashboard/jios/forms/JiosCreateEditForm.tsx
@@ -34,11 +34,13 @@ type Props = {
   title: string;
   onCancel: () => void;
   defaultValues?: Partial<JioCreateEditFormValues>;
+  disableDateTime?: boolean;
 };
 
 export default function JiosCreateEditForm({
   onSubmit,
   onCancel,
+  disableDateTime,
   defaultValues: currentJio,
   submitIcon,
   submitLabel,
@@ -166,37 +168,42 @@ export default function JiosCreateEditForm({
             ))}
           </RHFSelect>
 
-          <Typography variant="subtitle1" gutterBottom sx={{ mb: 2 }}>
-            Which date are you climbing on? (Optional)
-          </Typography>
-          <RHFDatePicker name="date" label="Date" />
-
-          {/* Display climbing time only when date is present */}
-          {formData.date && (
+          {/* Hide date time field if disableDateTime is true */}
+          {!disableDateTime && (
             <>
               <Typography variant="subtitle1" gutterBottom sx={{ mb: 2 }}>
-                What time are you climbing at?
+                Which date are you climbing on? (Optional)
               </Typography>
-              <Stack justifyContent="space-evenly" direction="row" spacing={2} sx={{ mt: 3 }}>
-                <RHFTextField
-                  size="medium"
-                  type="time"
-                  name="startTiming"
-                  label="Start Time"
-                  InputLabelProps={{
-                    shrink: true,
-                  }}
-                />
-                <RHFTextField
-                  size="medium"
-                  type="time"
-                  name="endTiming"
-                  label="End Time"
-                  InputLabelProps={{
-                    shrink: true,
-                  }}
-                />
-              </Stack>
+              <RHFDatePicker name="date" label="Date" />
+
+              {/* Display climbing time only when date is present */}
+              {formData.date && (
+                <>
+                  <Typography variant="subtitle1" gutterBottom sx={{ mb: 2 }}>
+                    What time are you climbing at?
+                  </Typography>
+                  <Stack justifyContent="space-evenly" direction="row" spacing={2} sx={{ mt: 3 }}>
+                    <RHFTextField
+                      size="medium"
+                      type="time"
+                      name="startTiming"
+                      label="Start Time"
+                      InputLabelProps={{
+                        shrink: true,
+                      }}
+                    />
+                    <RHFTextField
+                      size="medium"
+                      type="time"
+                      name="endTiming"
+                      label="End Time"
+                      InputLabelProps={{
+                        shrink: true,
+                      }}
+                    />
+                  </Stack>
+                </>
+              )}
             </>
           )}
 
@@ -258,6 +265,14 @@ export default function JiosCreateEditForm({
             placeholder=""
             fullWidth
           />
+
+          {disableDateTime && (
+            <Typography variant="body2" sx={{ mb: 2 }}>
+              Note: The date of this Jio cannot be modified because it wasn't specified when you
+              created it.
+            </Typography>
+          )}
+
           <Button
             className="jios-create-edit-submit"
             type="submit"


### PR DESCRIPTION
## Describe your changes

- As per discussion with @chownces 
  - Make date not nullable

## Changes

Backend

- DTO
  - [ ] Validate either both startDT and endDT absent OR both present (To be done next time)
- [x] Create
  - [x] If date null
    - [x] startDT = now, endDT = now + 2 months (backend set)
- [x] Search
  - [x] Remove null filter logic
- Telegram
  - [x] If start & end date different
    - [x] Put Anytime till (end date)
    - [x] Change to date fns

Frontend

- [x] If start & end date different
  - [x] Put Anytime till (end date)
- [x] Edit Jio
  - [x] If start & end date different
    - [x] Don't pass in start and end date data
    - [x] Hide date field and display date cannot be modified

## Issue ticket number and link

## Screenshots (if appropriate):

## Checklist before requesting a review

- [x] I have performed a self-review of my code
