### PR TITLE
fix: change to preload metadata

### DIFF
--- a/frontend/src/components/Video.tsx
+++ b/frontend/src/components/Video.tsx
@@ -53,8 +53,8 @@ export default function Video({ sx, cloudflareVideoUid, videoUrl, thumbnailSrc }
             '& div': { paddingTop: '0 !important', position: 'static !important' },
           }}
         >
-          {/* preload property auto fetches first few video segments if user has good internet */}
-          <Stream streamRef={streamRef} src={cloudflareVideoUid} muted controls preload="auto" />
+          {/* preload property fetches tiny bit of video and image */}
+          <Stream streamRef={streamRef} src={cloudflareVideoUid} muted controls preload="metadata" />
         </Box>
       );
     }


### PR DESCRIPTION
## Describe your changes

Fix video component to change to preload="metadata"

preload="auto" is wasting alot of streaming minutes on Cloudflare, that are not viewed

Before preload="auto"
<img width="285" alt="image" src="https://user-images.githubusercontent.com/24352004/203379612-6bf39170-d993-41d1-9647-4facee1000a6.png">

After preload="auto" (3 Nov)
<img width="1178" alt="image" src="https://user-images.githubusercontent.com/24352004/203379694-7426f10d-3580-422d-a355-212cbd698eaa.png">

Every 1000min costs USD1.

preload="metadata" works fine to as it fetches the video placeholder image and a tiny bit of the video. We could dramatically reduce costs, with tiny impact on UX.

See
https://clubmate.fi/what-does-the-preload-attribute-in-the-video-element-do

## Issue ticket number and link

## Screenshots (if appropriate):

## Checklist before requesting a review

- [x] I have performed a self-review of my code
