### PR TITLE
fix: Auto-filled jios clogging up the feed

### DIFF
--- a/backend/src/database/daos/posts/posts.dao.service.ts
+++ b/backend/src/database/daos/posts/posts.dao.service.ts
@@ -53,8 +53,8 @@ export class PostsDaoService {
   async getUpcomingPosts(search: SearchPostDto) {
     const query = this.postModel
       .query()
+      .orderByRaw('end_date_time::date ASC')
       .orderBy('startDateTime', 'ASC')
-      .orderBy('endDateTime', 'ASC')
       .orderBy('gymId', 'ASC')
       .withGraphFetched(PostsDaoService.allGraphs);
 


### PR DESCRIPTION
Problem is that auto-filled jios have a start_date of when it is created. This can be solved by reversing the sorting order. There is no need to sort by start_date first, as the primary case for sorting by start_date is to get an ascending order in time for jios.

## Describe your changes

## Issue ticket number and link
https://github.com/climbjios-sg/climbjios-app/issues/248

## Screenshots (if appropriate):
![Screenshot 2022-12-13 at 7 34 35 PM](https://user-images.githubusercontent.com/39303703/207307443-b44e7fea-afad-4b23-b2ec-5ab099d33910.png)

This PR will resort the jios by prioritizing the end dates. This is so that jios with auto-filled dates will not take up all the starting few pages of the feed (as it is previously sorted by start date).

This solution sorts by end_date, specifically using the date, and then by time, to achieve the same outcome in the beginning; to have jios sorted by time. This can be done as jios that have dates filled in, will have the same start & end dates. Solving it this way will also avoid having to over-complicate things by using database migrations.

## Checklist before requesting a review

- [] I have performed a self-review of my code
