### PR TITLE
fix: pressing enter key reloads enter username page

### DIFF
--- a/frontend/src/pages/onboarding/UsernameForm.tsx
+++ b/frontend/src/pages/onboarding/UsernameForm.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Stack, Typography } from '@mui/material';
 // components
 import { RHFTextField } from '../../components/hook-form';

--- a/frontend/src/pages/onboarding/UsernameForm.tsx
+++ b/frontend/src/pages/onboarding/UsernameForm.tsx
@@ -25,6 +25,7 @@ export const UsernameForm = () => {
         }}
         required
       />
+      <input hidden type="text"/>
     </Stack>
   );
 };


### PR DESCRIPTION
## Describe your changes
Added a hidden text field so the page is not reloaded when "enter" is pressed, which is a quirk as described [here](https://stackoverflow.com/questions/1370021/why-does-forms-with-single-input-field-submit-upon-pressing-enter-key-in-input)

## Issue ticket number and link
https://github.com/climbjios-sg/climbjios-app/issues/250

## Screenshots (if appropriate):

## Checklist before requesting a review

- Did `yarn test` in backend directory
