### PR TITLE
fix: bottom shadow of last card in list can't be seen

### DIFF
--- a/frontend/src/pages/dashboard/jios/list/allJios/index.tsx
+++ b/frontend/src/pages/dashboard/jios/list/allJios/index.tsx
@@ -88,7 +88,7 @@ export default function JioCardList() {
           scrollableTarget="root"
         >
           {data.map((jio) => (
-            <Box key={jio.id} sx={{ width: '100%', mt: 2 }}>
+            <Box key={jio.id} sx={{ width: '100%', mt: 2, mb: 2 }}>
               <JioCard data={jio} />
             </Box>
           ))}


### PR DESCRIPTION
## Describe your changes
Added bottom margin so the bottom shadow can be seen

## Issue ticket number and link

## Screenshots (if appropriate):
Before:
<img width="475" alt="Screenshot 2022-12-27 at 5 21 01 PM" src="https://user-images.githubusercontent.com/40333518/209646096-f71d1644-35cd-48c9-adee-ffbcbed6b4c2.png">

After:
<img width="474" alt="Screenshot 2022-12-27 at 5 20 13 PM" src="https://user-images.githubusercontent.com/40333518/209646111-79a78556-c39a-414c-b2a0-b8df85136d86.png">

## Checklist before requesting a review

- [x] I have performed a self-review of my code
