### PR TITLE
Feat: Tally user research

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -23,6 +23,9 @@
     content="The social network for climbers" />
   <meta name="keywords" content="react,material,kit,application,dashboard,admin,template" />
   <meta name="author" content="ClimbJios" />
+
+  <!-- Using Tally popup user survey -->
+  <script async src="https://tally.so/widgets/embed.js"></script>
 </head>
 
 <body>

--- a/frontend/src/components/TallyUserResearchPopup.tsx
+++ b/frontend/src/components/TallyUserResearchPopup.tsx
@@ -1,0 +1,37 @@
+import { useSnackbar } from 'notistack';
+import { Button } from '@mui/material';
+
+const useTallyUserResearchPopup = () => {
+  const { enqueueSnackbar, closeSnackbar } = useSnackbar();
+
+  return () =>
+    enqueueSnackbar('Hey, we need your help to serve you better!', {
+      variant: 'info',
+      persist: true,
+      action: (key) => (
+        <>
+          {/* ‹button data-tally-open="3xrNNk" data-tally-emoji-text="N data-tally-emoji-animation="wave" ›Click me</button> */}
+          <Button
+            // href="https://tally.so#tally-open-3xrNNk&tally-emoji-text=👋&tally-emoji-animation=wave"
+            data-tally-open="3xrNNk"
+            data-tally-emoji-text="👋"
+            data-tally-emoji-animation="wave"
+            onClick={() => {
+              closeSnackbar(key);
+            }}
+          >
+            Let's go!
+          </Button>
+          <Button
+            onClick={() => {
+              closeSnackbar(key);
+            }}
+          >
+            Later
+          </Button>
+        </>
+      ),
+    });
+};
+
+export default useTallyUserResearchPopup;

--- a/frontend/src/hooks/auth/useAutoLogin.ts
+++ b/frontend/src/hooks/auth/useAutoLogin.ts
@@ -48,6 +48,7 @@ const useAutoLogin = () => {
     clearRedirectPath,
     enqueueError,
     login,
+    setJustLoggedIn,
     redirectPath?.options,
     redirectPath?.to,
     searchParams,

--- a/frontend/src/hooks/auth/useAutoLogin.ts
+++ b/frontend/src/hooks/auth/useAutoLogin.ts
@@ -1,5 +1,6 @@
 import { useEffect } from 'react';
 import { useSearchParams } from 'react-router-dom';
+import useTallyUserResearchPopup from 'src/components/TallyUserResearchPopup';
 import { ACCESS_TOKEN, REFRESH_TOKEN } from 'src/utils/jwt';
 import useCustomSnackbar from '../useCustomSnackbar';
 import useRedirectPath from '../useRedirectPath';
@@ -13,6 +14,7 @@ const useAutoLogin = () => {
   const [searchParams] = useSearchParams();
   const { enqueueError } = useCustomSnackbar();
   const { redirectPath, clearRedirectPath } = useRedirectPath();
+  const openPopup = useTallyUserResearchPopup();
 
   useEffect(() => {
     const callLogin = async () => {
@@ -39,7 +41,9 @@ const useAutoLogin = () => {
     };
 
     callLogin();
+    openPopup()
   }, [
+    openPopup,
     clearRedirectPath,
     enqueueError,
     login,

--- a/frontend/src/hooks/auth/useAutoLogin.ts
+++ b/frontend/src/hooks/auth/useAutoLogin.ts
@@ -1,8 +1,8 @@
 import { useEffect } from 'react';
 import { useSearchParams } from 'react-router-dom';
-import useTallyUserResearchPopup from 'src/components/TallyUserResearchPopup';
 import { ACCESS_TOKEN, REFRESH_TOKEN } from 'src/utils/jwt';
 import useCustomSnackbar from '../useCustomSnackbar';
+import useLocalStorage from '../useLocalStorage';
 import useRedirectPath from '../useRedirectPath';
 import useLogin from './useLogin';
 
@@ -14,7 +14,9 @@ const useAutoLogin = () => {
   const [searchParams] = useSearchParams();
   const { enqueueError } = useCustomSnackbar();
   const { redirectPath, clearRedirectPath } = useRedirectPath();
-  const openPopup = useTallyUserResearchPopup();
+
+  //for tally user research
+  const { setValueInLocalStorage: setJustLoggedIn } = useLocalStorage('justLoggedIn', false);
 
   useEffect(() => {
     const callLogin = async () => {
@@ -41,9 +43,8 @@ const useAutoLogin = () => {
     };
 
     callLogin();
-    openPopup()
+    setJustLoggedIn(true);
   }, [
-    openPopup,
     clearRedirectPath,
     enqueueError,
     login,

--- a/frontend/src/hooks/guards/useCheckNotOnboarded.ts
+++ b/frontend/src/hooks/guards/useCheckNotOnboarded.ts
@@ -60,7 +60,7 @@ const useCheckNotOnboarded = (): CheckNotOnboarded => {
       }
     },
 
-    [authProvider, enqueueSnackbar, navigate]
+    [authProvider, justLoggedIn, setJustLoggedIn, openPopup, enqueueSnackbar, navigate]
   );
 
   return checkNotOnboarded;

--- a/frontend/src/pages/onboarding/index.tsx
+++ b/frontend/src/pages/onboarding/index.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement, useState, useMemo } from 'react';
+import { ReactElement, useState, useMemo } from 'react';
 
 // @mui
 import { Container, Typography, Button, Card, Stack } from '@mui/material';


### PR DESCRIPTION
## Describe your changes
Added a snackbar that shows up when checkNotOnboarded is triggered. The snackbar is only triggered if the user had just logged in, which is determined with a boolean stored in local storage, and set upon useAutoLogin. The snackbar prompts the user to tap a button that triggers the tally user research popup.

(there is also a minor change removing an unused import in an unrelated file)

## Issue ticket number and link

## Screenshots (if appropriate):

## Checklist before requesting a review

- [x] I have performed a self-review of my code

From what I could test, the snackbar only shows up for returning users (i.e. not the first time logging in) that have only just logged in.